### PR TITLE
Add support for multiple SKBs per IO request

### DIFF
--- a/ethblk.h
+++ b/ethblk.h
@@ -20,12 +20,6 @@
 #include <linux/udp.h>
 #include <net/ip.h>
 
-/* Defragment skb. Uncomment if kernel panics in ethblk_network_recv */
-#define ETHBLK_NETWORK_LINEARIZE_SKB
-
-/* Uncomment for IOPS estimation on a fully zero-copy IO path */
-//#define ETHBLK_INITIATOR_FAKE_ZEROCOPY
-
 #define VERSION "0.1"
 
 extern int net_stat;
@@ -113,11 +107,17 @@ struct ethblk_cfg_hdr {
 	__u8 uuid[UUID_SIZE];
 } __attribute__((packed));
 
+#define ETHBLK_HDR_SIZE \
+	(sizeof(struct ethblk_hdr))
+
 #define ETHBLK_CFG_REPLY_SIZE \
 	(sizeof(struct ethblk_hdr) + sizeof(struct ethblk_cfg_hdr))
 
 #define ETHBLK_HDR_L3_SIZE \
 	(sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct udphdr))
+
+#define ETHBLK_HDR_SIZE_FROM_CMD(cmd) \
+	(ETHBLK_HDR_SIZE + (cmd->l3 ? ETHBLK_HDR_L3_SIZE : 0))
 
 void ethblk_net_init(void);
 void ethblk_net_exit(void);

--- a/network.c
+++ b/network.c
@@ -111,16 +111,13 @@ struct ethblk_hdr *ethblk_network_skb_get_hdr(struct sk_buff *skb)
 {
 	return (struct ethblk_hdr *)(skb_mac_header(skb) +
 				     (ethblk_network_skb_is_l2(skb) ?
-				      0 :
-				      (sizeof(struct ethhdr) +
-				       sizeof(struct iphdr) +
-				       sizeof(struct udphdr))));
+				      0 : ETHBLK_HDR_L3_SIZE));
 }
 
 void *ethblk_network_skb_get_payload(struct sk_buff *skb)
 {
 	return ((unsigned char *)ethblk_network_skb_get_hdr(skb)
-		+ sizeof(struct ethblk_hdr));
+		+ ETHBLK_HDR_SIZE);
 }
 
 int ethblk_network_xmit_skb(struct sk_buff *skb)
@@ -177,12 +174,10 @@ static int ethblk_network_recv(struct sk_buff *skb, struct net_device *ifp,
 	/* don't process in net/core/ipv4 */
 	old_skb->pkt_type = PACKET_OTHERHOST;
 
-#ifdef ETHBLK_NETWORK_LINEARIZE_SKB
 	if (skb_linearize(skb)) {
 		dprintk_ratelimit(debug, "drop non-linearized skb %px\n", skb);
 		goto exit;
 	}
-#endif
 
 	skb_push(skb, ETH_HLEN);
 

--- a/scripts/ethblk-setup
+++ b/scripts/ethblk-setup
@@ -25,8 +25,9 @@ set_irq_affinity.sh ${nic} # from mlnx-en-utils
 max_rings=$(ethtool -g ${nic} | grep [RT]X: | head -2 | cut -c 1-3,6- | tr ':' ' ' | tr '[:upper:]' '[:lower:]')
 ethtool -G ${nic} $max_rings
 ethtool --set-priv-flags ${nic} rx_cqe_compress on
-ethtool -A ${nic} rx off tx off
-ifconfig ${nic} txqueuelen 20000
+ethtool -A ${nic} rx on tx on
+#ethtool -A ${nic} rx off tx off
+ifconfig ${nic} txqueuelen 100000
 
 sysctl -w net.core.netdev_budget=5000
 sysctl -w net.core.netdev_budget_usecs=10000
@@ -37,7 +38,8 @@ systemctl stop tuned
 #mlnx_tune -p HIGH_THROUGHPUT
 
 rmmod ethblk
-insmod ethblk.ko initiator=$ini target=$tgt disk_major=154 queue_depth=256 rps=$tgt ip_ports=256 force_dma_alignment=3 lat_stat=0
+#insmod ethblk.ko initiator=$ini target=$tgt disk_major=154 queue_depth=256 rps=1 ip_ports=256 lat_stat=0
+insmod ethblk.ko initiator=$ini target=$tgt disk_major=154 rps=1
 # uncomment for debug
 #echo module ethblk +p > /sys/kernel/debug/dynamic_debug/control
 


### PR DESCRIPTION
This allows ethblk to parity with nvmet on large block (> MTU).

One blk IO may have many SKBs. On timeout, only lost fragments are
retransmitted.