### PR TITLE
Compile fixes for newer kernel versions

### DIFF
--- a/target.c
+++ b/target.c
@@ -1077,8 +1077,13 @@ static void ethblk_target_cmd_rw(struct ethblk_target_cmd *cmd)
 
 	bio->bi_iter.bi_sector = lba;
 	bio_set_dev(bio, d->bd);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 	bio_set_op_attrs(bio, write ? REQ_OP_WRITE : REQ_OP_READ,
 			 (write ? REQ_SYNC | REQ_IDLE : 0));
+#else
+	bio->bi_opf = (write ? REQ_OP_WRITE : REQ_OP_READ) |
+			(write ? REQ_SYNC | REQ_IDLE : 0);
+#endif
 	bio->bi_end_io = ethblk_target_cmd_rw_complete;
 	bio->bi_private = cmd;
 	cmd->bio = bio;

--- a/target.c
+++ b/target.c
@@ -620,7 +620,11 @@ static int ethblk_target_disk_create(unsigned short drv_id, char *path)
 
 	snprintf(d->name, sizeof(d->name), "eda%d", drv_id);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
 	d->bd = blkdev_get_by_path(path, FMODE_READ | FMODE_WRITE, NULL);
+#else
+	d->bd = blkdev_get_by_path(path, FMODE_READ | FMODE_WRITE, NULL, NULL);
+#endif
 	if (IS_ERR(d->bd)) {
 		dprintk(err, "disk %s can't open backing store %s: %ld\n",
 			d->name, path, PTR_ERR(d->bd));


### PR DESCRIPTION
When trying to compile `ethblk` kernel module it failed due to kernel version changes.
Adjustment to fix compilation up-to kernel v6.5, which is still under development so I will only claim v6.5-rc1 works.